### PR TITLE
feat: size API overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,12 @@ yarn add use-gauge
 
 ## Usage
 
-
 🚨 Beware that this API is very much in flux! Breaking changes **will** occur, but I'll update these docs and the Codesandbox accordingly 🚨
 
 In your React project, import the `useGauge` hook and invoke it with the following parameters.
 
 ```tsx
 const {
-  ref,
   ticks,
   valueToAngle,
   angleToValue,
@@ -33,12 +31,12 @@ const {
   getLabelProps,
   getArcProps,
   getNeedleProps,
+  getSVGProps,
 } = useGauge({
   startAngle: 180, // determines where the gauge starts
   endAngle: 360, // determines where the gauge ends
   numTicks, // the number of ticks to display between the min and max values
-  size, // how large the chart should be (TODO: Investigate a better API)
-  padding, // Honestly kind of a misnomer, as it really just zooms the chart in and out. (TODO: Investigate a better API)
+  diameter, // diameter of the gauge itself
   domain: [minValue, maxValue], // Min and max values for your gauge. *Please* use a min that's smaller than the max :)
 });
 ```
@@ -47,12 +45,12 @@ If you want to skip ahead and see a fully baked implementation of this hook, che
 
 Otherwise, here's a brief explanation of how these returned values work.
 
-### ref
+### getSVGProps
 
-_Please_ be sure to apply this `ref` to your SVG component, as it's responsible for programatically updating the height, width, and viewBox of the element as a function of the `size` you provide. To be totally honest, I'm not in love with this API and really wish I could get rid of the `size` prop in earnest but this was the path of least resistance.
+_Please_ be sure to apply these props to your SVG element, as it's responsible for programatically updating the height, width, and viewBox of the element as a function of the `diameter` you provide.
 
 ```tsx
-<svg ref={ref}></svg>
+<svg {...getSVGProps()}></svg>
 ```
 
 ### ticks, getTickProps, getLabelProps, and angleToValue

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -15,7 +15,7 @@ const App = () => {
     endAngle,
     numTicks,
   } = useControls('Gauge settings', {
-    diameter: { value: 200 },
+    diameter: { value: 300 },
     value: { value: 0, min: 0, max: 100 },
     minValue: { value: 0 },
     maxValue: { value: 100 },
@@ -106,11 +106,7 @@ const App = () => {
 
   return (
     <div className="h-screen flex items-center justify-center">
-      <svg
-        // ref={ref}
-        {...getGaugeSVGProps()}
-        className="overflow-visible max-w-full border-2 border-gray-700"
-      >
+      <svg {...getGaugeSVGProps()} className="max-w-full overflow-visible">
         <path
           {...getArcProps({
             offset,

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -89,7 +89,7 @@ const App = () => {
     angleToValue,
     getArcProps,
     getNeedleProps,
-    getGaugeSVGProps,
+    getSVGProps,
   } = useGauge({
     startAngle,
     endAngle,
@@ -106,7 +106,7 @@ const App = () => {
 
   return (
     <div className="h-screen flex items-center justify-center">
-      <svg {...getGaugeSVGProps()} className="max-w-full overflow-visible">
+      <svg {...getSVGProps()} className="max-w-full overflow-visible">
         <path
           {...getArcProps({
             offset,

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -8,22 +8,20 @@ import { useControls } from 'leva';
 const App = () => {
   const {
     value,
-    size,
+    diameter,
     minValue,
     maxValue,
     startAngle,
     endAngle,
     numTicks,
-    padding,
   } = useControls('Gauge settings', {
-    size: { value: 200 },
+    diameter: { value: 200 },
     value: { value: 0, min: 0, max: 100 },
     minValue: { value: 0 },
     maxValue: { value: 100 },
-    startAngle: { value: 150, min: 0, max: 360, step: 1 },
-    endAngle: { value: 390, min: 0, max: 720, step: 1 },
+    startAngle: { value: 90, min: 0, max: 360, step: 1 },
+    endAngle: { value: 270, min: 0, max: 360, step: 1 },
     numTicks: { value: 11, min: 0, max: 30, step: 1 },
-    padding: { value: 0, min: 0, max: 100, step: 1 },
   });
 
   const {
@@ -84,7 +82,6 @@ const App = () => {
   });
 
   const {
-    ref,
     ticks,
     getTickProps,
     getLabelProps,
@@ -92,12 +89,12 @@ const App = () => {
     angleToValue,
     getArcProps,
     getNeedleProps,
+    getGaugeSVGProps,
   } = useGauge({
     startAngle,
     endAngle,
     numTicks,
-    size,
-    padding,
+    diameter,
     domain: [minValue, maxValue],
   });
 
@@ -110,7 +107,8 @@ const App = () => {
   return (
     <div className="h-screen flex items-center justify-center">
       <svg
-        ref={ref}
+        // ref={ref}
+        {...getGaugeSVGProps()}
         className="overflow-visible max-w-full border-2 border-gray-700"
       >
         <path

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -190,10 +190,10 @@ export function useGauge(params: UseGaugeParams) {
     };
 
     const [top, right, bottom, left] = [
-      getDistanceForDirection(180), // top,
-      getDistanceForDirection(270), // right,
-      getDistanceForDirection(0), // bottom,
-      getDistanceForDirection(90), // left,
+      getDistanceForDirection(180),
+      getDistanceForDirection(270),
+      getDistanceForDirection(0),
+      getDistanceForDirection(90),
     ];
 
     const width = left + right;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -169,11 +169,14 @@ export function useGauge(params: UseGaugeParams) {
     [valueToAngle, diameter, radius]
   );
 
-  const calculatediameterForDirection = (startAngle: number, deg: number) => {
-    const angle = startAngle - deg;
-    const distance = (Math.cos(degreesToRadians(angle)) * diameter) / 2;
-    return distance;
-  };
+  const calculatediameterForDirection = useCallback(
+    (startAngle: number, deg: number) => {
+      const angle = startAngle - deg;
+      const distance = (Math.cos(degreesToRadians(angle)) * diameter) / 2;
+      return distance;
+    },
+    [diameter]
+  );
 
   const getGaugeSVGProps = () => {
     const getDistanceForDirection = (deg: number) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -178,7 +178,7 @@ export function useGauge(params: UseGaugeParams) {
     [diameter]
   );
 
-  const getGaugeSVGProps = () => {
+  const getSVGProps = () => {
     const getDistanceForDirection = (deg: number) => {
       if (startAngle < deg && endAngle > deg) return diameter / 2;
       const startAngleDistance = calculatediameterForDirection(
@@ -219,6 +219,6 @@ export function useGauge(params: UseGaugeParams) {
     angleToValue,
     getArcProps,
     getNeedleProps,
-    getGaugeSVGProps,
+    getSVGProps,
   };
 }


### PR DESCRIPTION
- Removes the `ref` prop in favor of a `getSVGProps()` helper function
- Replaces the `size` pop with a `diameter` prop for more accurate description of sizing